### PR TITLE
Fixed YearView Calculations

### DIFF
--- a/client/src/pages/MonthView.tsx
+++ b/client/src/pages/MonthView.tsx
@@ -23,6 +23,7 @@ import {
   nextMonthAction,
   setYearAction,
   updateEntriesAction,
+  setMonthAction,
 } from '../store/CalculatedMonthDataStore'
 import { IAccount, IEntry } from '../common/types'
 import EntryForm from '../components/forms/Entry'
@@ -100,6 +101,7 @@ const MonthView: FC<IProps> = ({
   renderHeaders,
   propEntries,
   propAccounts,
+  month,
 }) => {
   const [state, dispatch] = useReducer(
     calculatedDataStoreReducer,
@@ -123,6 +125,9 @@ const MonthView: FC<IProps> = ({
   // on startup
   useEffect(() => {
     dispatch(setYearAction(date.getFullYear()))
+    if (month !== undefined) {
+      dispatch(setMonthAction(month))
+    }
   }, [])
 
   useEffect(() => {

--- a/client/src/pages/YearView.tsx
+++ b/client/src/pages/YearView.tsx
@@ -94,7 +94,7 @@ const YearView: FC = () => {
   const renderRow = (month: string, i: number) => {
     const [openMonthList, setOpenMonthList] = useState(false)
     return (
-      <Accordion TransitionProps={{ unmountOnExit: true }}>
+      <Accordion key={i} TransitionProps={{ unmountOnExit: true }}>
         <AccordionSummary>
           <Grid container onClick={() => setOpenMonthList(!openMonthList)}>
             <Grid item xs={4} md={4}>
@@ -121,6 +121,7 @@ const YearView: FC = () => {
               renderHeaders={false}
               propEntries={entries}
               propAccounts={accounts}
+              month={i}
             />
           </div>
         </AccordionDetails>

--- a/client/src/store/CalculatedMonthDataStore.ts
+++ b/client/src/store/CalculatedMonthDataStore.ts
@@ -160,14 +160,6 @@ export const calculatedDataStoreReducer = (
     }
     // Dispatch needs to be called if entries need to be updated
     case ECalculatedDataStoreAction.UPDATE_ENTRIES: {
-      const getBalanceUpToMonth = (monthIndex: number) => {
-        let total = 0
-        for (let i = 0; i < monthIndex; i++) {
-          total += state.calculatedMonthData[i].balance
-        }
-        return total
-      }
-
       const entries = action.payload.entries
       const accounts = action.payload.accounts
 
@@ -189,13 +181,13 @@ export const calculatedDataStoreReducer = (
         state.calculatedMonthData[i].monthlyIncome = monthlyIncome
         state.calculatedMonthData[i].monthlyExpense = monthlyExpense
         const incomeAmountList = monthlyIncome.map(
-          (month) => month.monthlyAmount!
+          (entry) => entry.monthlyAmount[i]!
         )
         state.calculatedMonthData[i].incomeTotal = sumUp(
           incomeAmountList.flat()
         )
         const expenseAmountList = monthlyExpense.map(
-          (month) => month.monthlyAmount!
+          (entry) => entry.monthlyAmount[i]!
         )
         state.calculatedMonthData[i].expenseTotal = sumUp(
           expenseAmountList.flat()
@@ -203,8 +195,16 @@ export const calculatedDataStoreReducer = (
         state.calculatedMonthData[i].balance =
           state.calculatedMonthData[i].incomeTotal -
           state.calculatedMonthData[i].expenseTotal
+
+        let totalAccountBalanceToApply = 0
+        if (i === 0) {
+          totalAccountBalanceToApply = state.totalAccountAppliedToBudget
+        } else {
+          totalAccountBalanceToApply =
+            state.calculatedMonthData[i - 1].endOfMonthTotal
+        }
         state.calculatedMonthData[i].endOfMonthTotal =
-          state.calculatedMonthData[i].balance + getBalanceUpToMonth(i + 1)
+          totalAccountBalanceToApply + state.calculatedMonthData[i].balance
       })
 
       return {


### PR DESCRIPTION
**In YearView,**
- For TotalInBank column, January will start with the applied total of all accounts and all other months will start with the previous month's TotalInBank.
- For each row, the income and expense totals were fixed to be the totals for that month only.

**In MonthView,**
- Added optional prop for month index and added a `setMonthAction` to the startup `useEffect` if index is defined.

**Screenshot**
![image](https://user-images.githubusercontent.com/24469190/108600840-49af8f00-7367-11eb-9bd2-baf2d304df9a.png)
